### PR TITLE
Create Prismatty console color helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
 # Prismatty
-Chalk alternative
+
+Prismatty is a tiny ANSI color helper that makes it easy to add rich styles to Node.js console output without pulling in a large dependency. It provides composable helpers, pre-built palettes for foreground and background colors, and first-class TypeScript definitions.
+
+## Installation
+
+```bash
+npm install prismatty
+```
+
+## Quick start
+
+```js
+const prism = require('prismatty');
+
+console.log(prism('Hello, world!', 'green'));
+console.log(prism.colorize('Something went wrong', { color: 'white', background: 'red', modifiers: 'bold' }));
+
+const warn = prism.compose('yellow', 'bold');
+console.log(warn('Caution!'));
+
+const highlight = prism.compose('cyan').with('underline');
+console.log(highlight`Value: ${42}`);
+
+console.log(prism.strip(prism.colors.magenta('plain text')));
+```
+
+## API
+
+### `prism(value, ...styles)` / `prism.colorize(value, ...styles)`
+
+Formats any value by applying one or more styles. Styles can be:
+
+- A color name (foreground or background).
+- A modifier name such as `bold` or `underline`.
+- An options object: `{ color, background, modifiers }`.
+- Nested arrays that combine any of the above.
+
+Later style arguments override earlier ones for foreground/background colors, while modifiers accumulate uniquely.
+
+```js
+prism('Server ready', 'green', 'bold');
+prism.colorize('Error', { color: 'white', background: 'red', modifiers: ['bold', 'underline'] });
+```
+
+### `prism.compose(...styles)` / `prism.with(...styles)`
+
+Returns a reusable formatter function. Formatters can be called like a normal function or used as template literal tags, and support further composition via `.compose()` / `.with()`.
+
+```js
+const success = prism.compose('green', 'bold');
+console.log(success('OK'));
+
+const loud = success.compose({ modifiers: ['underline'] });
+console.log(loud('Look at me!'));
+```
+
+### `prism.colors`, `prism.backgrounds`, `prism.modifiers`
+
+Pre-built formatter maps for every supported foreground color, background color, and modifier. Aliases are provided where appropriate (e.g. both `gray` and `grey`).
+
+```js
+console.log(prism.colors.brightBlue('Info message'));
+console.log(prism.backgrounds.gray('On gray background'));
+console.log(prism.modifiers.underline('Important'));  
+```
+
+### `prism.strip(value)`
+
+Removes ANSI escape sequences from a string.
+
+```js
+const styled = prism.colors.red('alert');
+console.log(prism.strip(styled)); // "alert"
+```
+
+### `prism.available`
+
+Lists the canonical foreground colors, background colors, and modifiers bundled with Prismatty.
+
+```js
+console.log(prism.available.colors);
+```
+
+## Supported styles
+
+**Foreground colors**: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray`, `brightBlack`, `brightRed`, `brightGreen`, `brightYellow`, `brightBlue`, `brightMagenta`, `brightCyan`, `brightWhite` (alias: `grey`).
+
+**Background colors**: same set as foreground colors (also with `grey` alias).
+
+**Modifiers**: `bold`, `dim`, `italic`, `underline`, `blink`, `inverse`, `hidden`, `strikethrough` (aliases: `faint`, `conceal`, `strike`, `strikethru`).
+
+You can also use the literal style names (including aliases) as plain strings inside `prism()` or `prism.compose()` calls.
+
+## TypeScript support
+
+`index.d.ts` ships with exhaustive type information, including unions for style names, reusable formatter types, and the normalized style descriptor shape. Merge-friendly namespaces mean you can leverage `prism.StyleInput`, `prism.PrismFormatter`, and other helper types in strongly typed codebases.
+
+## Testing
+
+Run the built-in test suite with:
+
+```bash
+npm test
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,149 @@
+declare const prism: prism.Prism;
+
+declare namespace prism {
+  type ForegroundColorCanonical =
+    | 'black'
+    | 'red'
+    | 'green'
+    | 'yellow'
+    | 'blue'
+    | 'magenta'
+    | 'cyan'
+    | 'white'
+    | 'gray'
+    | 'brightBlack'
+    | 'brightRed'
+    | 'brightGreen'
+    | 'brightYellow'
+    | 'brightBlue'
+    | 'brightMagenta'
+    | 'brightCyan'
+    | 'brightWhite';
+
+  type BackgroundColorCanonical =
+    | 'black'
+    | 'red'
+    | 'green'
+    | 'yellow'
+    | 'blue'
+    | 'magenta'
+    | 'cyan'
+    | 'white'
+    | 'gray'
+    | 'brightBlack'
+    | 'brightRed'
+    | 'brightGreen'
+    | 'brightYellow'
+    | 'brightBlue'
+    | 'brightMagenta'
+    | 'brightCyan'
+    | 'brightWhite';
+
+  type ForegroundColor = ForegroundColorCanonical | 'grey';
+  type BackgroundColor = BackgroundColorCanonical | 'grey';
+
+  type ModifierCanonical =
+    | 'reset'
+    | 'bold'
+    | 'dim'
+    | 'italic'
+    | 'underline'
+    | 'blink'
+    | 'inverse'
+    | 'hidden'
+    | 'strikethrough';
+
+  type ModifierAlias = 'faint' | 'conceal' | 'strike' | 'strikethru';
+
+  type Modifier = ModifierCanonical | ModifierAlias;
+  type ModifierWithoutReset = Exclude<ModifierCanonical, 'reset'>;
+
+  interface ColorInfo {
+    readonly name: ForegroundColorCanonical;
+    readonly code: number;
+  }
+
+  interface BackgroundInfo {
+    readonly name: BackgroundColorCanonical;
+    readonly code: number;
+  }
+
+  interface ModifierInfo {
+    readonly name: ModifierCanonical;
+    readonly code: number;
+  }
+
+  interface NormalizedStyle {
+    readonly color: ColorInfo | null;
+    readonly background: BackgroundInfo | null;
+    readonly modifiers: readonly ModifierInfo[];
+  }
+
+  type ModifierCollection = Modifier | readonly Modifier[];
+
+  interface PrismStyleOptions {
+    readonly color?: ForegroundColor | null;
+    readonly foreground?: ForegroundColor | null;
+    readonly fg?: ForegroundColor | null;
+    readonly background?: BackgroundColor | null;
+    readonly bg?: BackgroundColor | null;
+    readonly backgroundColor?: BackgroundColor | null;
+    readonly bgColor?: BackgroundColor | null;
+    readonly modifiers?: ModifierCollection | null;
+    readonly modifier?: ModifierCollection | null;
+    readonly effects?: ModifierCollection | null;
+    readonly effect?: ModifierCollection | null;
+    readonly styles?: ModifierCollection | null;
+    readonly style?: ModifierCollection | null;
+  }
+
+  type StyleName = ForegroundColor | BackgroundColor | Modifier;
+  type StyleInput = StyleName | PrismStyleOptions | NormalizedStyle | readonly StyleInput[];
+
+  interface Colorize {
+    (value: unknown, ...styles: StyleInput[]): string;
+  }
+
+  interface PrismFormatter extends Colorize {
+    readonly style: NormalizedStyle;
+    compose(...styles: StyleInput[]): PrismFormatter;
+    with(...styles: StyleInput[]): PrismFormatter;
+  }
+
+  interface PrismColorFormatters extends Record<ForegroundColorCanonical, PrismFormatter> {
+    readonly grey: PrismFormatter;
+  }
+
+  interface PrismBackgroundFormatters extends Record<BackgroundColorCanonical, PrismFormatter> {
+    readonly grey: PrismFormatter;
+  }
+
+  type PrismModifierFormatters = Record<ModifierWithoutReset, PrismFormatter>;
+
+  interface AvailableStyles {
+    readonly colors: readonly ForegroundColorCanonical[];
+    readonly backgrounds: readonly BackgroundColorCanonical[];
+    readonly modifiers: readonly ModifierWithoutReset[];
+  }
+
+  interface Prism extends Colorize {
+    readonly colorize: Colorize;
+    compose(...styles: StyleInput[]): PrismFormatter;
+    with(...styles: StyleInput[]): PrismFormatter;
+    readonly strip: (value: unknown) => string;
+    readonly colors: PrismColorFormatters;
+    readonly backgrounds: PrismBackgroundFormatters;
+    readonly modifiers: PrismModifierFormatters;
+    readonly available: AvailableStyles;
+  }
+
+  const colorize: Colorize;
+  const compose: (...styles: StyleInput[]) => PrismFormatter;
+  const strip: (value: unknown) => string;
+  const colors: PrismColorFormatters;
+  const backgrounds: PrismBackgroundFormatters;
+  const modifiers: PrismModifierFormatters;
+  const available: AvailableStyles;
+}
+
+export = prism;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,481 @@
+'use strict';
+
+const ESC = '\u001B[';
+const RESET = `${ESC}0m`;
+const ANSI_PATTERN = /\u001B\[[0-9;]*m/g;
+const IS_NORMALIZED = Symbol.for('prismatty.normalized');
+
+function normalizeKey(name) {
+  if (typeof name === 'object' && name && typeof name.name === 'string') {
+    name = name.name;
+  }
+
+  if (typeof name !== 'string') {
+    name = String(name);
+  }
+
+  return name.trim().toLowerCase().replace(/[\s_-]+/g, '');
+}
+
+function createLookup(canonical, aliases = {}) {
+  const entries = [];
+  const lookup = new Map();
+
+  for (const [name, code] of Object.entries(canonical)) {
+    const entry = Object.freeze({ name, code });
+    entries.push(entry);
+    lookup.set(normalizeKey(name), entry);
+  }
+
+  for (const [alias, target] of Object.entries(aliases)) {
+    const key = normalizeKey(alias);
+    const targetKey = normalizeKey(target);
+    const entry = lookup.get(targetKey);
+
+    if (!entry) {
+      throw new Error(`Unknown alias target: ${target}`);
+    }
+
+    lookup.set(key, entry);
+  }
+
+  return { entries: Object.freeze(entries.slice()), lookup };
+}
+
+const FOREGROUND = createLookup(
+  {
+    black: 30,
+    red: 31,
+    green: 32,
+    yellow: 33,
+    blue: 34,
+    magenta: 35,
+    cyan: 36,
+    white: 37,
+    gray: 90,
+    brightBlack: 90,
+    brightRed: 91,
+    brightGreen: 92,
+    brightYellow: 93,
+    brightBlue: 94,
+    brightMagenta: 95,
+    brightCyan: 96,
+    brightWhite: 97
+  },
+  {
+    grey: 'gray'
+  }
+);
+
+const BACKGROUND = createLookup(
+  {
+    black: 40,
+    red: 41,
+    green: 42,
+    yellow: 43,
+    blue: 44,
+    magenta: 45,
+    cyan: 46,
+    white: 47,
+    gray: 100,
+    brightBlack: 100,
+    brightRed: 101,
+    brightGreen: 102,
+    brightYellow: 103,
+    brightBlue: 104,
+    brightMagenta: 105,
+    brightCyan: 106,
+    brightWhite: 107
+  },
+  {
+    grey: 'gray'
+  }
+);
+
+const MODIFIER = createLookup(
+  {
+    reset: 0,
+    bold: 1,
+    dim: 2,
+    italic: 3,
+    underline: 4,
+    blink: 5,
+    inverse: 7,
+    hidden: 8,
+    strikethrough: 9
+  },
+  {
+    faint: 'dim',
+    conceal: 'hidden',
+    strike: 'strikethrough',
+    strikethru: 'strikethrough'
+  }
+);
+
+function resolveEntry(value, table, typeName) {
+  if (value && typeof value === 'object' && typeof value.name === 'string' && typeof value.code === 'number') {
+    const entry = table.get(normalizeKey(value.name));
+    if (entry && entry.code === value.code) {
+      return entry;
+    }
+  }
+
+  const key = normalizeKey(value);
+
+  if (!key) {
+    throw new Error(`Unknown ${typeName}: ${value}`);
+  }
+
+  const entry = table.get(key);
+
+  if (!entry) {
+    throw new Error(`Unknown ${typeName}: ${value}`);
+  }
+
+  return entry;
+}
+
+function resolveForeground(value) {
+  return resolveEntry(value, FOREGROUND.lookup, 'color');
+}
+
+function resolveBackground(value) {
+  return resolveEntry(value, BACKGROUND.lookup, 'background color');
+}
+
+function resolveModifier(value) {
+  return resolveEntry(value, MODIFIER.lookup, 'modifier');
+}
+
+function toArray(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (value && typeof value !== 'string' && typeof value[Symbol.iterator] === 'function') {
+    return Array.from(value);
+  }
+
+  return [value];
+}
+
+function flattenStyles(styles) {
+  const stack = Array.isArray(styles) ? styles.slice().reverse() : [styles];
+  const flattened = [];
+
+  while (stack.length) {
+    const item = stack.pop();
+
+    if (item === null || item === undefined || item === false) {
+      continue;
+    }
+
+    if (Array.isArray(item)) {
+      for (let i = item.length - 1; i >= 0; i -= 1) {
+        stack.push(item[i]);
+      }
+      continue;
+    }
+
+    flattened.push(item);
+  }
+
+  return flattened;
+}
+
+function parseStyleEntry(entry) {
+  if (entry === null || entry === undefined || entry === false) {
+    return null;
+  }
+
+  if (entry && entry[IS_NORMALIZED]) {
+    return entry;
+  }
+
+  if (typeof entry === 'string') {
+    if (!entry.trim()) {
+      return null;
+    }
+
+    const key = normalizeKey(entry);
+
+    const modifier = MODIFIER.lookup.get(key);
+    if (modifier) {
+      return { color: null, background: null, modifiers: [modifier] };
+    }
+
+    const foreground = FOREGROUND.lookup.get(key);
+    if (foreground) {
+      return { color: foreground, background: null, modifiers: [] };
+    }
+
+    const background = BACKGROUND.lookup.get(key);
+    if (background) {
+      return { color: null, background, modifiers: [] };
+    }
+
+    throw new Error(`Unknown style: ${entry}`);
+  }
+
+  if (typeof entry === 'object') {
+    const result = { color: null, background: null, modifiers: [] };
+
+    const colorValue = entry.color ?? entry.foreground ?? entry.fg;
+    if (colorValue !== undefined && colorValue !== null) {
+      result.color = resolveForeground(colorValue);
+    }
+
+    const backgroundValue = entry.background ?? entry.bg ?? entry.backgroundColor ?? entry.bgColor;
+    if (backgroundValue !== undefined && backgroundValue !== null) {
+      result.background = resolveBackground(backgroundValue);
+    }
+
+    const modifiersValue =
+      entry.modifiers ?? entry.modifier ?? entry.effects ?? entry.effect ?? entry.styles ?? entry.style;
+
+    if (modifiersValue !== undefined && modifiersValue !== null) {
+      for (const modifierValue of toArray(modifiersValue)) {
+        result.modifiers.push(resolveModifier(modifierValue));
+      }
+    }
+
+    return result;
+  }
+
+  throw new Error(`Unsupported style type: ${typeof entry}`);
+}
+
+function finalizeNormalized(base) {
+  const normalized = {
+    color: base.color || null,
+    background: base.background || null,
+    modifiers: Object.freeze(Array.from(base.modifiers.values()))
+  };
+
+  return Object.freeze(
+    Object.defineProperty(normalized, IS_NORMALIZED, {
+      value: true,
+      enumerable: false,
+      configurable: false,
+      writable: false
+    })
+  );
+}
+
+function normalizeStyles(styles) {
+  const flattened = flattenStyles(styles || []);
+  const base = {
+    color: null,
+    background: null,
+    modifiers: new Map()
+  };
+
+  for (const entry of flattened) {
+    const parsed = parseStyleEntry(entry);
+
+    if (!parsed) {
+      continue;
+    }
+
+    if (parsed.color !== null && parsed.color !== undefined) {
+      base.color = parsed.color;
+    }
+
+    if (parsed.background !== null && parsed.background !== undefined) {
+      base.background = parsed.background;
+    }
+
+    if (parsed.modifiers && parsed.modifiers.length) {
+      for (const modifier of parsed.modifiers) {
+        base.modifiers.set(modifier.name, modifier);
+      }
+    }
+  }
+
+  return finalizeNormalized(base);
+}
+
+function formatInput(args) {
+  if (args.length === 0) {
+    return '';
+  }
+
+  const [first, ...rest] = args;
+
+  if (Array.isArray(first) && Object.prototype.hasOwnProperty.call(first, 'raw')) {
+    let result = '';
+
+    for (let i = 0; i < first.length; i += 1) {
+      result += first[i];
+      if (i < rest.length) {
+        result += String(rest[i]);
+      }
+    }
+
+    return result;
+  }
+
+  return [first, ...rest].map((value) => String(value)).join(' ');
+}
+
+function applyNormalizedStyle(value, normalized) {
+  const text = String(value);
+  const codes = [];
+
+  if (normalized.modifiers.length) {
+    for (const modifier of normalized.modifiers) {
+      codes.push(modifier.code);
+    }
+  }
+
+  if (normalized.color) {
+    codes.push(normalized.color.code);
+  }
+
+  if (normalized.background) {
+    codes.push(normalized.background.code);
+  }
+
+  if (!codes.length) {
+    return text;
+  }
+
+  return `${ESC}${codes.join(';')}m${text}${RESET}`;
+}
+
+function colorize(value, ...styles) {
+  const normalized = normalizeStyles(styles);
+  return applyNormalizedStyle(value, normalized);
+}
+
+function createFormatterFromNormalized(normalized) {
+  const formatter = (...args) => applyNormalizedStyle(formatInput(args), normalized);
+
+  Object.defineProperty(formatter, 'style', {
+    value: normalized,
+    enumerable: true,
+    configurable: false,
+    writable: false
+  });
+
+  formatter.compose = (...styles) => createFormatterFromNormalized(normalizeStyles([normalized, ...styles]));
+  formatter.with = formatter.compose;
+
+  return formatter;
+}
+
+function compose(...styles) {
+  const normalized = normalizeStyles(styles);
+  return createFormatterFromNormalized(normalized);
+}
+
+function normalizedFromEntry(type, entry) {
+  const base = {
+    color: null,
+    background: null,
+    modifiers: new Map()
+  };
+
+  if (type === 'color') {
+    base.color = entry;
+  } else if (type === 'background') {
+    base.background = entry;
+  } else if (type === 'modifier') {
+    base.modifiers.set(entry.name, entry);
+  }
+
+  return finalizeNormalized(base);
+}
+
+function createFormatterMap(entries, type) {
+  const map = {};
+
+  for (const entry of entries) {
+    map[entry.name] = createFormatterFromNormalized(normalizedFromEntry(type, entry));
+  }
+
+  return map;
+}
+
+const colors = createFormatterMap(FOREGROUND.entries, 'color');
+
+if (colors.gray && !colors.grey) {
+  Object.defineProperty(colors, 'grey', {
+    value: colors.gray,
+    enumerable: true,
+    configurable: false,
+    writable: false
+  });
+}
+
+const backgrounds = createFormatterMap(BACKGROUND.entries, 'background');
+
+if (backgrounds.gray && !backgrounds.grey) {
+  Object.defineProperty(backgrounds, 'grey', {
+    value: backgrounds.gray,
+    enumerable: true,
+    configurable: false,
+    writable: false
+  });
+}
+
+const modifiers = createFormatterMap(
+  MODIFIER.entries.filter((entry) => entry.name !== 'reset'),
+  'modifier'
+);
+
+Object.freeze(colors);
+Object.freeze(backgrounds);
+Object.freeze(modifiers);
+
+const available = Object.freeze({
+  colors: Object.freeze(FOREGROUND.entries.map((entry) => entry.name)),
+  backgrounds: Object.freeze(BACKGROUND.entries.map((entry) => entry.name)),
+  modifiers: Object.freeze(MODIFIER.entries.filter((entry) => entry.name !== 'reset').map((entry) => entry.name))
+});
+
+function strip(value) {
+  return String(value).replace(ANSI_PATTERN, '');
+}
+
+const prism = function prism(value, ...styles) {
+  return colorize(value, ...styles);
+};
+
+Object.defineProperties(prism, {
+  colorize: {
+    value: colorize,
+    enumerable: true
+  },
+  compose: {
+    value: compose,
+    enumerable: true
+  },
+  with: {
+    value: compose,
+    enumerable: true
+  },
+  strip: {
+    value: strip,
+    enumerable: true
+  },
+  colors: {
+    value: colors,
+    enumerable: true
+  },
+  backgrounds: {
+    value: backgrounds,
+    enumerable: true
+  },
+  modifiers: {
+    value: modifiers,
+    enumerable: true
+  },
+  available: {
+    value: available,
+    enumerable: true
+  }
+});
+
+module.exports = prism;
+module.exports.default = prism;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "prismatty",
+  "version": "0.1.0",
+  "description": "Lightweight ANSI color styling helpers for Node.js consoles.",
+  "license": "MIT",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "default": "./index.js"
+    }
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "ansi",
+    "color",
+    "console",
+    "terminal",
+    "styling"
+  ],
+  "scripts": {
+    "test": "node ./test/run-tests.js"
+  },
+  "sideEffects": false,
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const assert = require('assert');
+const prism = require('..');
+
+const results = [];
+
+function test(name, fn) {
+  results.push({ name, fn });
+}
+
+test('colorize applies foreground color', () => {
+  const actual = prism('hello', 'red');
+  assert.strictEqual(actual, '\u001B[31mhello\u001B[0m');
+});
+
+test('colorize combines modifiers and colors', () => {
+  const actual = prism.colorize('hi', 'bold', 'green');
+  assert.strictEqual(actual, '\u001B[1;32mhi\u001B[0m');
+});
+
+test('colorize accepts option objects and arrays', () => {
+  const actual = prism(
+    'alert',
+    { color: 'white', background: 'red', modifiers: ['bold', 'underline'] },
+    ['blink']
+  );
+  assert.strictEqual(actual, '\u001B[1;4;5;37;41malert\u001B[0m');
+});
+
+test('compose produces reusable formatter', () => {
+  const warn = prism.compose('yellow', 'bold');
+  assert.strictEqual(warn('Careful!'), '\u001B[1;33mCareful!\u001B[0m');
+});
+
+test('compose supports chaining with with()', () => {
+  const base = prism.compose('magenta');
+  const loud = base.with('bold');
+  assert.strictEqual(loud('Notice'), '\u001B[1;35mNotice\u001B[0m');
+});
+
+test('compose works with normalized style reuse', () => {
+  const base = prism.compose('cyan');
+  const extra = base.compose(base.style, 'underline');
+  assert.strictEqual(extra('Value'), '\u001B[4;36mValue\u001B[0m');
+});
+
+test('formatter joins multiple arguments with spaces', () => {
+  const formatted = prism.colors.green('value', 42, true);
+  assert.strictEqual(formatted, '\u001B[32mvalue 42 true\u001B[0m');
+});
+
+test('template literal usage', () => {
+  const highlight = prism.compose('cyan', 'underline');
+  assert.strictEqual(highlight`Answer: ${42}`, '\u001B[4;36mAnswer: 42\u001B[0m');
+});
+
+test('prebuilt formatters work for colors, backgrounds, and modifiers', () => {
+  assert.strictEqual(prism.colors.brightBlue('info'), '\u001B[94minfo\u001B[0m');
+  assert.strictEqual(prism.colors.grey('tone'), '\u001B[90mtone\u001B[0m');
+  assert.strictEqual(prism.backgrounds.brightYellow('bg'), '\u001B[103mbg\u001B[0m');
+  assert.strictEqual(prism.backgrounds.grey('bg'), '\u001B[100mbg\u001B[0m');
+  assert.strictEqual(prism.modifiers.underline('text'), '\u001B[4mtext\u001B[0m');
+});
+
+test('strip removes ANSI codes', () => {
+  const styled = prism.colors.red('danger');
+  assert.strictEqual(prism.strip(styled), 'danger');
+});
+
+test('available metadata lists canonical styles', () => {
+  assert.ok(prism.available.colors.includes('brightBlue'));
+  assert.ok(prism.available.backgrounds.includes('brightYellow'));
+  assert.ok(prism.available.modifiers.includes('italic'));
+});
+
+test('aliases resolve correctly', () => {
+  assert.strictEqual(prism('tone', 'grey'), '\u001B[90mtone\u001B[0m');
+  assert.strictEqual(prism('whisper', 'faint'), '\u001B[2mwhisper\u001B[0m');
+});
+
+test('null and undefined styles are ignored', () => {
+  assert.strictEqual(prism('plain', null, undefined), 'plain');
+});
+
+test('compose with no styles returns identity formatter', () => {
+  const identity = prism.compose();
+  assert.strictEqual(identity('value'), 'value');
+});
+
+test('invalid style names throw helpful errors', () => {
+  assert.throws(() => prism('oops', 'unknown-style'), /Unknown style/);
+});
+
+test('background options accept shorthand keys', () => {
+  const formatted = prism('note', { bg: 'blue', modifiers: 'italic' });
+  assert.strictEqual(formatted, '\u001B[3;44mnote\u001B[0m');
+});
+
+test('modifiers accumulate uniquely', () => {
+  const formatted = prism('unique', 'bold', ['bold', 'underline']);
+  assert.strictEqual(formatted, '\u001B[1;4munique\u001B[0m');
+});
+
+(async () => {
+  let passed = 0;
+  for (const { name, fn } of results) {
+    try {
+      await fn();
+      console.log(`✅ ${name}`);
+      passed += 1;
+    } catch (error) {
+      console.error(`❌ ${name}`);
+      console.error(error);
+      process.exitCode = 1;
+      break;
+    }
+  }
+
+  if (process.exitCode) {
+    console.error(`\n${passed}/${results.length} tests passed`);
+  } else {
+    console.log(`\n${passed}/${results.length} tests passed`);
+  }
+})();


### PR DESCRIPTION
## Summary
- implement the Prismatty console styling API with composable helpers and palette metadata
- add TypeScript typings and npm package metadata so the module can be published easily
- create documentation and automated tests covering the primary styling features

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d08de6d6288328b198b363c708f1bb